### PR TITLE
docs(coral-react): fix readme install command

### DIFF
--- a/packages/coral-react/README.md
+++ b/packages/coral-react/README.md
@@ -19,7 +19,7 @@ Read the full docs at https://divetool.github.io/coral
 To start using Coral's React components, start by installing `@divetool/coral-react` in your React project.
 
 ```bash
-npm install @divetool/coral-angular
+npm install @divetool/coral-react
 ```
 
 Then import the components into your application TSX/JSX.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/divetool/coral/blob/main/docs/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(coral): button content overflow` -->

## Current Behavior

<!-- This is the behavior we have today -->
The react package README install command was pointing to the angular package

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
The react package install command should point to `@divetool/cora-react` 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

# Checklist:

<!-- - [ ] My code follows the [developer guidelines of this project](https://github.com/divetool/coral/blob/main/docs/CONTRIBUTING.md) -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
