### PR TITLE
feat(coral): enable experimental import injection

### DIFF
--- a/packages/coral/stencil.config.ts
+++ b/packages/coral/stencil.config.ts
@@ -15,6 +15,9 @@ export const config: Config = {
   namespace: 'coral',
   taskQueue: 'async',
   plugins: [sass()],
+  extras: {
+    experimentalImportInjection: true,
+  },
   outputTargets: [
     {
       type: 'dist',


### PR DESCRIPTION
add experimental import injection to support bundlers like Vite

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/divetool/coral/blob/main/docs/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(coral): button content overflow` -->

## Current Behavior

<!-- This is the behavior we have today -->
For dev servers with bundlers like Vite, the lazy loaded components can not be resolved. 

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
Adding the experimental import injection in the stencil build configuration, let's us support bundlers like Vite.

This may have an impact in out bundle size, so it would be important to keep track of it as the component library grows. 

Read more here: https://stenciljs.com/docs/config-extras#experimentalimportinjection

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

# Checklist:

<!-- - [ ] My code follows the [developer guidelines of this project](https://github.com/divetool/coral/blob/main/docs/CONTRIBUTING.md) -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
